### PR TITLE
#27 date skip bug

### DIFF
--- a/app/src/main/java/com/example/cram_project/MainActivity.java
+++ b/app/src/main/java/com/example/cram_project/MainActivity.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.DatePicker;
@@ -17,6 +16,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -84,6 +84,42 @@ public class MainActivity extends AppCompatActivity {
         mStartDisplayDate = findViewById(R.id.startDateID);
         mEndDisplayDate = findViewById(R.id.endDateID);
         mExamDisplayDate = findViewById(R.id.examDateID);
+
+        //TEST SUBJECTS TO BE REMOVED IN FINAL BUILDDDDDD
+        Subject CSF = new Subject(
+                "CSF",
+                27,
+                new ArrayList<>(Arrays.asList(1, 2, 3)),
+                1,
+                toDate(1 + "/" + 5 + "/" + 2021),
+                toDate(22 + "/" + 5 + "/" + 2021),
+                toDate(23 + "/" + 5 + "/" + 2021)
+        );
+        Subject MHCI = new Subject(
+                "MHCI",
+                11,
+                new ArrayList<>(Arrays.asList(1, 2)),
+                2,
+                toDate(1 + "/" + 5 + "/" + 2021),
+                toDate(20 + "/" + 5 + "/" + 2021),
+                toDate(21 + "/" + 5 + "/" + 2021)
+        );
+        Subject PSD = new Subject(
+                "PSD",
+                12,
+                new ArrayList<>(Arrays.asList(1)),
+                3,
+                toDate(4 + "/" + 5 + "/" + 2021),
+                toDate(26 + "/" + 5 + "/" + 2021),
+                toDate(27 + "/" + 5 + "/" + 2021)
+        );
+
+        subjects.add(CSF);
+        subjects.add(MHCI);
+        subjects.add(PSD);
+
+        earliestDate = toDate(1 + "/" + 5 + "/" + 2021);
+        latestDate = toDate(26 + "/" + 5 + "/" + 2021);
 
 
         // Enter start date
@@ -199,6 +235,7 @@ public class MainActivity extends AppCompatActivity {
         });
 
 
+
         // submit subject button
         submitButton.setOnClickListener(new View.OnClickListener(){
             @Override
@@ -288,7 +325,7 @@ public class MainActivity extends AppCompatActivity {
                     daysToSkip.add("Sunday");
                 }
 
-                skipDates = daysBetweenDates(earliestDate, latestDate, daysToSkip);
+                skipDates = daysBetweenDates(earliestDate, Spread.incrementDateBy(latestDate, 1), daysToSkip);
                 calendar = Spread.spread(subjects, skipDates);
                 outputText = translateToString(calendar);
                 Intent doneOutput = new Intent(MainActivity.this, workloadOutput.class);

--- a/app/src/main/java/com/example/cram_project/MainActivity.java
+++ b/app/src/main/java/com/example/cram_project/MainActivity.java
@@ -21,7 +21,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 

--- a/app/src/main/java/com/example/cram_project/Spread.java
+++ b/app/src/main/java/com/example/cram_project/Spread.java
@@ -1,14 +1,12 @@
 package com.example.cram_project;
 
 import android.annotation.TargetApi;
-import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +23,6 @@ public class Spread {
                 skip_dates.add(subjects.get(i).examDate);
             }
         }
-        Log.i("days to skip", Integer.toString(skip_dates.size()));
         //spreading out workload process
         Map<Date, HashMap<String, ArrayList<Workload>>> calendar = new HashMap<>();
         for(Subject subject : subjects) {
@@ -37,7 +34,6 @@ public class Spread {
                     total_days -= 1;
                 }
             }
-            Log.i("total study days left", Long.toString(total_days));
 
             //evenly spread remaining workload between available days.
             int workPosition = 0;
@@ -46,13 +42,17 @@ public class Spread {
             double remainingSize = (double)subject.remainingWork.size()-1;
 
             //Finds evenly spread out values between 0.0 and total available days.
-            //Start-date + the floor of each value is the date a workload is to be completed.
+            //Start_date + the floor of each value is the date a workload is to be completed.
             for(double i=0.0; i<=total_days+0.0001; i += total_days/remainingSize) {
-
                 dateToStore = incrementDateBy(subject.startDate, Math.floor(i)+skipValue);
-                while(skip_dates.contains(dateToStore)) {
+                while(skip_dates.contains(dateToStore)) {       //if dateToBeAdded is to be skipped, go forward a day until you find free day
                     skipValue += 1.0;
                     dateToStore = incrementDateBy(subject.startDate, Math.floor(i)+skipValue);
+                }
+                if(dateToStore.after(subject.endDate)){         //if dateToBeAdded is AFTER end_date, go back a day until you find free day before end date
+                    while(skip_dates.contains(dateToStore) || dateToStore.after(subject.endDate)){
+                        dateToStore = decrementDateBy1(dateToStore);
+                    }
                 }
 
                 calendar.putIfAbsent(dateToStore, new HashMap<String, ArrayList<Workload>>());
@@ -77,7 +77,6 @@ public class Spread {
             //if previous date is weighted 2 or more in difficulty than current date, use wlToMove method to decide which workloads in the
             //previous date to move forward to the current date.
             if(prevDifficulty-currentDifficulty>1) {
-                Log.i("difficulty difference", Integer.toString(prevDifficulty-currentDifficulty));
                 HashMap<String, ArrayList<Workload>> wlToMove = findWlToMove(sortedMap.get(prevDate), Math.floorDiv(prevDifficulty-currentDifficulty,2), date, subjects);
 
                 for(String subj : wlToMove.keySet()) {
@@ -91,10 +90,26 @@ public class Spread {
                     }
                 }
             }
+
+            //if current date is weighted 2 or more in difficulty than previous date, use wlToMove method to decide which workloads in the
+            //current date to move back to the previous date.
+            else if(currentDifficulty-prevDifficulty>1 && prevDate != null) {
+                HashMap<String, ArrayList<Workload>> wlToMove = findWlToMove(sortedMap.get(date), Math.floorDiv(currentDifficulty-prevDifficulty,2), prevDate, subjects);
+
+                for (String subj : wlToMove.keySet()) {
+                    for (Workload wl : wlToMove.get(subj)) {
+                        sortedMap.get(prevDate).putIfAbsent(subj, new ArrayList<Workload>());
+                        sortedMap.get(prevDate).get(subj).add(wl);
+                        sortedMap.get(date).get(subj).remove(wl);
+                        if (sortedMap.get(date).get(subj).isEmpty()) {
+                            sortedMap.get(date).remove(subj);
+                        }
+                    }
+                }
+            }
             prevDifficulty = currentDifficulty;
             prevDate = date;
         }
-
         return sortedMap;
     }
 
@@ -106,6 +121,14 @@ public class Spread {
         return c.getTime();
     }
 
+    public static Date decrementDateBy1(Date currentDate){
+        Calendar cal = Calendar.getInstance();
+        cal.setTime (currentDate); // convert your date to Calendar object
+        cal.add(Calendar.DATE, -1);
+        return cal.getTime(); // again get back your date object
+    }
+
+    //NEXT STEP IS TO CREATE A REVERSE OF THIS METHOD!!!!!!!!!!!!!!!!!!!!!
     //helper method to find out which workloads to move from previous date to current date for equal spreading purposes.
     public static HashMap<String, ArrayList<Workload>> findWlToMove(HashMap<String, ArrayList<Workload>> workload, Integer difficulty, Date currentDate, ArrayList<Subject> subjects) {
         HashMap<String, ArrayList<Workload>> wlToMove = new HashMap<>();
@@ -114,16 +137,16 @@ public class Spread {
 
         for(String subject : workload.keySet()) {
             //check if current subject being checked's end date comes AFTER the date workloads are being moved to
-            boolean beforeEnd = false;
+            boolean beforeEndAndAfterStart = false;
             for(Subject s : subjects){
                 if (s.name == subject){
-                    if(s.endDate == currentDate || s.endDate.after(currentDate)){
-                        beforeEnd = true;
+                    if((s.endDate == currentDate || s.endDate.after(currentDate)) && (s.startDate == currentDate || s.startDate.before(currentDate))){
+                        beforeEndAndAfterStart = true;
                         break;
                     }
                 }
             }
-            if(beforeEnd) {
+            if(beforeEndAndAfterStart) {
                 //find the correct workloads to move forward
                 for (Workload wl : workload.get(subject)) {
                     //if this workload is the exact difficulty weighting we're looking for, return that workload and we're done
@@ -131,7 +154,6 @@ public class Spread {
                         finalWl = new ArrayList<>(Arrays.asList(wl));
                         wlToMove = new HashMap<>();
                         wlToMove.put(subject, finalWl);
-                        Log.i("wlToMove", Integer.toString(finalWl.size()));
                         return wlToMove;
                     //if this workload is less than the difficulty we're looking for AND less than current found difficulty weighting -> add to workloads to be added list
                     } else if (wl.difficulty < difficulty && currentDifficultyTotal < difficulty - wl.difficulty) {
@@ -140,7 +162,6 @@ public class Spread {
                         } else {
                             finalWl = new ArrayList<>(Arrays.asList(wl));
                             wlToMove.put(subject, finalWl);
-                            Log.i("wlToMove", Integer.toString(finalWl.size()));
                         }
                         currentDifficultyTotal += wl.difficulty;
                     }


### PR DESCRIPTION
Date skips now fully work
- if a day cannot be worked on, it will not be allocated any work (this wasn't working towards the end of the calendar but fixed now)
- workloads will no longer exceed their subject's end date

Spread class now spreads more accurately
- difficulty weight difference between two neighbouring dates rarely exceed 2 (unless a subject is finished with which is meant to be the case)